### PR TITLE
Capture the traceback in thread jobs

### DIFF
--- a/test/test-traceback.lua
+++ b/test/test-traceback.lua
@@ -1,0 +1,19 @@
+local Threads = require 'threads'
+Threads.serialization('threads.sharedserialize')
+
+my_threads = Threads(1,
+            function()
+                -- nothing
+            end)
+
+my_threads:addjob(function()
+    function evil_func()
+        print('a'+1)
+    end
+    print("I'm doing fine")
+    evil_func()
+ end)
+
+ok, res = pcall(my_threads.synchronize, my_threads)
+assert(ok == false)
+assert(res:find("in function 'evil_func'"))


### PR DESCRIPTION
When an error occurs inside a torch threads, the whole stack trace is now passed back instead of just the error message.

Maybe we want to be able to switch this on/off, but my feeling is you always want the traceback.