### PR TITLE
Fix double terminate error

### DIFF
--- a/threads.lua
+++ b/threads.lua
@@ -270,7 +270,10 @@ function Threads:terminate()
       return
    end
 
-   -- terminate the threads
+   -- terminate user jobs
+   self:synchronize()
+
+   -- add jobs to terminate all threads
    for i=1,self.N do
       if self:specific() then
          self:addjob(
@@ -286,7 +289,7 @@ function Threads:terminate()
       end
    end
 
-   -- terminate all jobs
+   -- wait for all threads to terminate
    self:synchronize()
 
    -- wait for threads to exit (and free them)


### PR DESCRIPTION
Following the documentation about [terminate](https://github.com/torch/threads/tree/203972852a877d3f623b8dd4a84e669b2a1e544e#threadsterminate) it says that it automatically calls [synchronize](https://github.com/torch/threads/tree/203972852a877d3f623b8dd4a84e669b2a1e544e#threadssynchronize).
If we have some jobs running and we call terminate, we have the expected behavior of it waiting for our jobs to complete then stopping the pool then returning.
Unfortunately, of there is any error in our jobs, the `terminate` call will hang forever.

This is due to the fact that in `terminate`, before calling `synchronize`, we add jobs [here](https://github.com/torch/threads/blob/203972852a877d3f623b8dd4a84e669b2a1e544e/threads.lua#L282-L285) to stop the main loops of the threads . So when calling `synchronize` [here](https://github.com/torch/threads/blob/203972852a877d3f623b8dd4a84e669b2a1e544e/threads.lua#L290), the threads' main loops are stopped before we check for errors. When we detect an error, we raise it, triggering the gc on the thread pool. The gc function for the thread pool is just calling `terminate`. This nested call re-adds the jobs to stop the threads' main loops and wait for their completion. But they are already stopped (so these jobs are never processed) and we hang forever waiting for these jobs to complete.

In this fix, we first complete all user jobs (and raise an error if one failed) before sending the signal to the threads to stop their main loop.

EDIT: Example:
This will hang forever with the current state of master.
```lua
local threads = require 'threads'

local pool = threads.Threads(1)

pool:addjob(
	function()
		error('Child thread error')
	end
	)

pool:terminate()
```