### PR TITLE
Nonblocking dojob

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,10 @@ In this case a value of `1` is received by the main thread as argument `inc` to 
 This demonstrates how communication between threads is easily achieved using the `addjob` method.
 
 <a name='threads.dojob'/>
-#### Threads:dojob() ####
+#### Threads:dojob(isnonblocking=nil) ####
 This method is used to tell the main thread to execute the next `endcallback` in the queue (see [Threads:addjob](#threads.addjob)).
-If no such job is available, the main thread of execution will wait (i.e. block) until the `mainthread` Queue (i.e. queue) is filled with a job.
+If no such job is available, the main thread of execution will either `isnonblocking=nil|false` wait (i.e. block) until the `mainthread` Queue (i.e. queue) is filled with a job or 
+`isnonblocking=true` return imedidately. The return value indidate the number of jobs done (0 or 1). The default behavior is block waiting.
 
 In general, this method should not be called, except if one wants to use the [async capabilities](#threads.async) of the Threads class.
 Instead, [synchronize()](#threads.synchronize) should be called to make sure all jobs are executed.
@@ -299,9 +300,12 @@ specifically, it is thus important to check for errors with
 [synchronize()](#threads.synchronize) if a problem occurred.
 
 <a name='threads.synchronize'/>
-#### Threads:synchronize() ####
+#### Threads:synchronize(isnonblocking=nil) ####
 This method will call [dojob](#threads.dojob) until all `callbacks` and corresponding `endcallbacks` are executed on the queue and main threads, respectively.
 This method will also raise an error for any errors raised in the pool of queue threads.
+
+if `isnonblocking` is set to `true`, the method only synchronize those threads with finished `callbacks` and wait for their corresponding `endcallbacks` to finish.
+The returned integer indicate the number of threads synchronized.
 
 <a name='threads.terminate'/>
 #### Threads:terminate() ####
@@ -374,10 +378,12 @@ Both the `callback` function and `...` arguments are serialized before being *pu
 If the queue is full, i.e. it has more than `N` jobs, the calling thread will wait (i.e. block) until a job is retrieved by another thread.
 
 <a name='queue.dojob'/>
-#### [res] Queue:dojob() ####
+#### [res] Queue:dojob(isnonblocking=nil) ####
 This method is called by a thread to *get*, unserialize and execute a job inserted via [addjob](#queue.addjob) from the queue.
-A calling thread will wait (i.e. block) until a new job can be retrieved.
+A calling thread will wait (i.e. block) until a new job can be retrieved by default `isnonblocking=false|nil`.
 It returns to the calller whatever the job function returns after execution.
+
+Alternatively, when `isnonblocking=true`, it would return `nil` when the queue is empty.
 
 <a name='threads.serialize'/>
 ### Serialize ###

--- a/queue.lua
+++ b/queue.lua
@@ -36,12 +36,17 @@ function Queue:addjob(callback, ...)
    end
 end
 
-function Queue:dojob()
+function Queue:dojob(isnonblocking)
    local status, msg = pcall(
       function()
          local serialize = require(self.serialize)
 
          self.mutex:lock()
+         if isnonblocking~=nil and isnonblocking and self.isempty == 1 then
+             self.mutex:unlock()
+             return {}
+         end
+
          while self.isempty == 1 do
             self.notempty:wait(self.mutex)
          end

--- a/queue.lua
+++ b/queue.lua
@@ -44,7 +44,7 @@ function Queue:dojob(isnonblocking)
          self.mutex:lock()
          if isnonblocking~=nil and isnonblocking and self.isempty == 1 then
              self.mutex:unlock()
-             return {}
+             return nil
          end
 
          while self.isempty == 1 do

--- a/test/test-threads-async-nonblocking.lua
+++ b/test/test-threads-async-nonblocking.lua
@@ -1,0 +1,72 @@
+local threads = require 'threads'
+
+local nthread = 4
+local njob = 100
+
+local pool = threads.Threads(
+   nthread,
+   function(threadid)
+      print('starting a new thread/state number ' .. threadid)
+   end
+)
+
+
+local jobid = 0
+local result -- DO NOT put this in get
+local function get()
+   
+   -- fill up the queue as much as we can
+   -- this will not block
+   while jobid < njob and pool:acceptsjob() do
+      jobid = jobid + 1
+      
+      pool:addjob(
+         function(jobid)
+            print(string.format('thread ID %d is performing job %d', __threadid, jobid))
+            return string.format("job output from job %d", jobid)
+         end,
+
+         function(jobres)
+            result = jobres
+         end,
+
+         jobid
+      )
+   end
+
+   -- is there still something to do?
+   if pool:hasjob() then
+      local isnonblocking=true --if true, dojob may return nil when no job is in the endcallqueue
+      local endcalldone=pool:dojob(isnonblocking) -- yes? do it!
+      if pool:haserror() then -- check for errors
+         pool:synchronize() -- finish everything and throw error
+      end
+      if endcalldone > 0 then
+          return result --return job results
+      else
+          return false --singaling didn't processing any jobs
+      end
+   end
+
+   return nil --signalling no more jobs
+end
+
+local jobdone = 0
+repeat   
+   -- get something asynchronously
+   local res = get()
+   
+   -- do something with res (if any)
+   if res then
+      print(res)
+      jobdone = jobdone + 1
+   end
+   
+until res==nil -- until there is nothing remaining
+
+assert(jobid == 100)
+assert(jobdone == 100)
+
+print('PASSED')
+
+pool:terminate()


### PR DESCRIPTION
 add non-blocking option to Threads.{dojob,synchronize}, Queue.dojob along with a unit-test.

A non-blocking Thread.dojob will only process endcallbackqueue but not block waiting for threadqueue to finish. A return value indicates the number of job endcallbacks processed. This useful when the main thread cannot be blocked waiting for worker threads. A polling approach should be used instead.
