### PR TITLE
Add threads.Channel: a blocking, buffered queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(luasrc
   serialize.lua
   sharedserialize.lua
   queue.lua
+  channel.lua
 )
 
 add_torch_package(threads "${src}" "${luasrc}" "Threads")

--- a/channel.lua
+++ b/channel.lua
@@ -1,0 +1,63 @@
+require 'torch'
+local clib = require 'libthreads'
+local Threads = require 'threads.threads'
+
+local M = {}
+local Channel = torch.class('threads.Channel', M)
+
+function Channel:__init(n)
+   assert(n >= 0, 'invalid size: ' .. tostring(n))
+   self.__channel = clib.channel(n)
+end
+
+function Channel:send(value)
+   local serialize = require(Threads.__serialize)
+   self.__channel:send(serialize.save(value), false)
+end
+
+function Channel:isend(value)
+   local serialize = require(Threads.__serialize)
+   return self.__channel:send(serialize.save(value), true)
+end
+
+function Channel:values()
+   return function()
+      return self:receive()
+   end
+end
+
+function Channel:receive()
+   local serialize = require(Threads.__serialize)
+   local value, ok = self.__channel:receive(false)
+   if ok then
+      value = serialize.load(value)
+   end
+   return value, ok
+end
+
+function Channel:ireceive()
+   local serialize = require(Threads.__serialize)
+   local value, ok = self.__channel:receive(true)
+   if ok then
+      value = serialize.load(value)
+   end
+   return value, ok
+end
+
+function Channel:close()
+   self.__channel:close()
+end
+
+function Channel:__write(f)
+   assert(torch.type(f) == 'torch.MemoryFile', 'can only serialize to shared memory')
+   clib.channel.retain(self.__channel)
+   f:writeDouble(self.__channel:id())
+end
+
+function Channel:__read(f)
+   assert(torch.type(f) == 'torch.MemoryFile', 'can only serialize to shared memory')
+   local id = f:readDouble()
+   self.__channel = clib.channel.fromid(id)
+end
+
+return M.Channel

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,7 @@ local C = require 'libthreads'
 threads.Thread = C.Thread
 threads.Mutex = C.Mutex
 threads.Condition = C.Condition
+threads.Channel = require 'threads.channel'
 threads.Threads = require 'threads.threads'
 
 -- only for backward compatibility (boo)

--- a/lib/THThread.c
+++ b/lib/THThread.c
@@ -81,6 +81,11 @@ int pthread_cond_signal(pthread_cond_t *cond)
   return SetEvent(*cond) == 0;
 }
 
+int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+  return SetEvent(*cond) == 0;
+}
+
 #else
 #error no thread system available
 #endif
@@ -218,6 +223,13 @@ long THCondition_id(THCondition *self)
 int THCondition_signal(THCondition *self)
 {
   if(pthread_cond_signal(&self->id))
+    return 1;
+  return 0;
+}
+
+int THCondition_broadcast(THCondition *self)
+{
+  if(pthread_cond_broadcast(&self->id))
     return 1;
   return 0;
 }

--- a/lib/THThread.h
+++ b/lib/THThread.h
@@ -20,6 +20,7 @@ THCondition* THCondition_new(void);
 THCondition* THCondition_newWithId(long id);
 long THCondition_id(THCondition *self);
 int THCondition_signal(THCondition *self);
+int THCondition_broadcast(THCondition *self);
 int THCondition_wait(THCondition *self, THMutex *mutex);
 void THCondition_free(THCondition *self);
 

--- a/lib/channel.c
+++ b/lib/channel.c
@@ -1,0 +1,247 @@
+#include "TH.h" /* for THCharStorage */
+#include "luaT.h" /* for handling THCHarStorage */
+#include "luaTHRD.h"
+#include "THThread.h"
+#include <lua.h>
+#include <lualib.h>
+
+
+typedef struct THChannel_ {
+  THMutex *mutex;
+  THCondition *notfull;
+  THCondition *notempty;
+  THCharStorage **args;
+
+  unsigned int head;
+  unsigned int tail;
+  unsigned int size;
+  int isempty;
+  int isfull;
+  int isclosed;
+  int refcount;
+} THChannel;
+
+static int channel_new(lua_State *L)
+{
+  int size = luaL_checkinteger(L, 1);
+  if (size < 0) luaL_error(L, "threads: invalid channel size");
+
+  THChannel* channel = (THChannel*) calloc(1, sizeof(THChannel));
+  if (!channel) luaL_error(L, "threads: channel new out of memory");
+
+  channel->mutex = THMutex_new();
+  channel->notfull = THCondition_new();
+  channel->notempty = THCondition_new();
+  channel->args = calloc(size, sizeof(THCharStorage*));
+  channel->isempty = 1;
+  channel->isfull = 0;
+  channel->refcount = 1;
+  channel->size = size;
+
+  if(!channel->mutex || !channel->notfull || !channel->notempty ||
+     !channel->args) {
+    goto error;
+  }
+
+  if(!luaTHRD_pushudata(L, channel, "threads.channel")) {
+    goto error;
+  }
+
+  return 1;
+
+error:
+  THMutex_free(channel->mutex);
+  THCondition_free(channel->notfull);
+  THCondition_free(channel->notempty);
+  free(channel->args);
+  free(channel);
+  luaL_error(L, "threads: channel new out of memory");
+  return 0;
+}
+
+static int channel_fromid(lua_State *L)
+{
+  long id = luaL_checknumber(L, 1);
+  THChannel* channel = (THChannel*) id;
+  if (luaTHRD_pushudata(L, channel, "threads.channel")) {
+    THAtomicIncrementRef(&channel->refcount);
+    return 1;
+  }
+  luaL_error(L, "threads: channel fromid out of memory");
+  return 0;
+}
+
+static int channel_free(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+  if(THAtomicDecrementRef(&channel->refcount))
+  {
+    int i;
+    THMutex_free(channel->mutex);
+    THCondition_free(channel->notfull);
+    THCondition_free(channel->notempty);
+    for(i = 0; i < channel->size; i++) {
+      if(channel->args[i])
+        THCharStorage_free(channel->args[i]);
+    }
+    free(channel->args);
+    free(channel);
+  }
+  return 0;
+}
+
+static int channel_retain(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+  THAtomicIncrementRef(&channel->refcount);
+  return 0;
+}
+
+static int channel_send(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+  THCharStorage *storage = luaT_checkudata(L, 2, "torch.CharStorage");
+  int immediate = lua_toboolean(L, 3);
+
+  THMutex_lock(channel->mutex);
+  while (channel->isfull && !channel->isclosed) {
+    if (immediate) {
+      lua_pushboolean(L, 0);
+      THMutex_unlock(channel->mutex);
+      return 1;
+    }
+
+    THCondition_wait(channel->notfull, channel->mutex);
+  }
+
+  if (channel->isclosed) {
+    THMutex_unlock(channel->mutex);
+    luaL_error(L, "threads: channel is closed");
+    return 0;
+  }
+
+  THCharStorage_retain(storage);
+  channel->args[channel->tail] = storage;
+  channel->tail++;
+  if (channel->tail >= channel->size) {
+    channel->tail = 0;
+  }
+  channel->isfull = (channel->tail == channel->head);
+  channel->isempty = 0;
+
+  THMutex_unlock(channel->mutex);
+  THCondition_signal(channel->notempty);
+
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+static int channel_receive(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+  int immediate = lua_toboolean(L, 2);
+
+  THMutex_lock(channel->mutex);
+  while (channel->isempty) {
+    if (immediate || channel->isclosed) {
+      lua_pushnil(L);
+      lua_pushboolean(L, 0);
+      THMutex_unlock(channel->mutex);
+      return 2;
+    }
+
+    THCondition_wait(channel->notempty, channel->mutex);
+  }
+
+  THCharStorage* storage = channel->args[channel->head];
+  channel->args[channel->head] = NULL;
+  channel->head++;
+  if (channel->head >= channel->size) {
+    channel->head = 0;
+  }
+  channel->isfull = 0;
+  channel->isempty = (channel->tail == channel->head);
+
+  THMutex_unlock(channel->mutex);
+  THCondition_signal(channel->notfull);
+
+  luaT_pushudata(L, storage, "torch.CharStorage");
+  lua_pushboolean(L, 1);
+
+  return 2;
+}
+
+static int channel_close(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+
+  THMutex_lock(channel->mutex);
+  channel->isclosed = 1;
+  THMutex_unlock(channel->mutex);
+
+  THCondition_broadcast(channel->notfull);
+  THCondition_broadcast(channel->notempty);
+
+  return 0;
+}
+
+static int channel_id(lua_State *L)
+{
+  THChannel *channel = luaTHRD_checkudata(L, 1, "threads.channel");
+  lua_pushinteger(L, (long)channel);
+  return 1;
+}
+
+static int channel__index(lua_State *L)
+{
+  luaTHRD_checkudata(L, 1, "threads.channel");
+  lua_getmetatable(L, 1);
+  if(lua_isstring(L, 2)) {
+    lua_pushstring(L, "__get");
+    lua_rawget(L, -2);
+    lua_pushvalue(L, 2);
+    lua_rawget(L, -2);
+    return 1;
+  }
+  lua_insert(L, -2);
+  lua_rawget(L, -2);
+  return 1;
+}
+
+
+static const struct luaL_Reg channel__ [] = {
+  {"new", channel_new},
+  {"fromid", channel_fromid},
+  {"retain", channel_retain},
+  {"free", channel_free},
+  {"id", channel_id},
+  {"__gc", channel_free},
+  {"__index", channel__index},
+  {NULL, NULL}
+};
+
+static const struct luaL_Reg channel_get__ [] = {
+  {"send", channel_send},
+  {"receive", channel_receive},
+  {"close", channel_close},
+  {"id", channel_id},
+  {NULL, NULL}
+};
+
+static void channel_init_pkg(lua_State *L)
+{
+  if(!luaL_newmetatable(L, "threads.channel"))
+    luaL_error(L, "threads: threads.channel type already exists");
+  luaL_setfuncs(L, channel__, 0);
+
+  lua_pushstring(L, "__get");
+  lua_newtable(L);
+  luaL_setfuncs(L, channel_get__, 0);
+  lua_rawset(L, -3);
+
+  lua_pop(L, 1);
+
+  lua_pushstring(L, "channel");
+  luaTHRD_pushctortable(L, channel_new, "threads.channel");
+  lua_rawset(L, -3);
+}

--- a/lib/init.c
+++ b/lib/init.c
@@ -19,11 +19,13 @@ static void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup)
 
 #include "threads.c"
 #include "queue.c"
+#include "channel.c"
 
 int luaopen_libthreads(lua_State *L)
 {
   lua_newtable(L);
   thread_init_pkg(L);
   queue_init_pkg(L);
+  channel_init_pkg(L);
   return 1;
 }

--- a/test/test-channel.lua
+++ b/test/test-channel.lua
@@ -1,0 +1,64 @@
+local sys = require 'sys'
+local t = require 'threads'
+
+-- Example 1. Two child threads send even and odd numbers
+-- The main thread collates the results
+local odd = t.Channel(1)
+local even = t.Channel(1)
+
+local pool = t.Threads(2)
+
+pool:addjob(function()
+  for i=1,100,2 do
+    odd:send(i)
+  end
+end)
+
+pool:addjob(function()
+  for i=2,100,2 do
+    even:send(i)
+  end
+end)
+
+for i=1,100 do
+  local v
+  if i % 2 == 1 then
+    v = odd:receive()
+  else
+    v = even:receive()
+  end
+  assert(v == i)
+end
+
+pool:synchronize()
+
+-- Example 2. Close should immediately cause the channel to return
+local ch = t.Channel(1)
+pool:addjob(function()
+  local v, ok = ch:receive()
+  assert(v == nil and ok == false)
+end)
+
+pool:addjob(function()
+  local v, ok = ch:receive()
+  assert(v == nil and ok == false)
+end)
+
+sys.sleep(0.01)
+ch:close()
+pool:synchronize()
+
+
+-- Example 3. Immedate sends and receives
+local ch = t.Channel(2)
+assert(ch:isend('a') == true)
+assert(ch:isend('b') == true)
+assert(ch:isend('c') == false)
+local v, ok = ch:ireceive()
+assert(v == 'a' and ok == true)
+v, ok = ch:ireceive()
+assert(v == 'b' and ok == true)
+v, ok = ch:ireceive()
+assert(v == nil and ok == false)
+
+print('OK')

--- a/threads.lua
+++ b/threads.lua
@@ -59,6 +59,7 @@ function Threads.new(N, ...)
          string.format(
             [[
   local Queue = require 'threads.queue'
+  require 'threads.channel'
   __threadid = %d
   local mainqueue = Queue(%d)
   local threadqueue = Queue(%d)


### PR DESCRIPTION
Sometimes it's hard to express multi-threaded programs using just threads and queues.

This adds a new general purpose class, threads.Channel, to provide a thread-safe way to communicate values between threads. A channel is a buffered queue similar to Java's BlockingQueue or Go's channels.

An example is included in test/test-channel.lua