### PR TITLE
Fix travis build for Lua 5.1 and Lua 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,37 +19,36 @@ addons:
     - gfortran-multilib
     - liblapack-dev
     - build-essential
-    - gcc 
-    - g++ 
+    - gcc
+    - g++
     - curl
-    - cmake 
-    - libreadline-dev 
-    - git-core 
-    - libqt4-core 
+    - cmake
+    - libreadline-dev
+    - git-core
+    - libqt4-core
     - libqt4-gui
-    - libqt4-dev 
-    - libjpeg-dev 
-    - libpng-dev 
+    - libqt4-dev
+    - libjpeg-dev
+    - libpng-dev
     - ncurses-dev
-    - imagemagick 
-    - libzmq3-dev 
-    - gfortran 
-    - unzip 
+    - imagemagick
+    - libzmq3-dev
+    - gfortran
+    - unzip
     - gnuplot
-    - gnuplot-x11 
-before_script: 
+    - gnuplot-x11
+before_script:
 - export ROOT_TRAVIS_DIR=$(pwd)
 - export INSTALL_PREFIX=~/torch/install
--  ls $HOME/OpenBlasInstall/lib || (cd /tmp/ && git clone https://github.com/xianyi/OpenBLAS.git -b master && cd OpenBLAS && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null) && make PREFIX=$HOME/OpenBlasInstall install)
 - git clone https://github.com/torch/distro.git ~/torch --recursive
 - cd ~/torch && git submodule update --init --recursive
 - mkdir build && cd build
-- export CMAKE_LIBRARY_PATH=$HOME/OpenBlasInstall/include:$HOME/OpenBlasInstall/lib:$CMAKE_LIBRARY_PATH
 - cmake .. -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE=Release -DWITH_${TORCH_LUA_VERSION}=ON
 - make && make install
 - cd $ROOT_TRAVIS_DIR
 - export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
-script: 
+- if [[ ! "$TORCH_LUA_VERSION" =~ "LUAJIT" ]]; then ${INSTALL_PREFIX}/bin/luarocks install luaffi; fi
+script:
 - ${INSTALL_PREFIX}/bin/luarocks make rocks/threads-scm-1.rockspec
 - export PATH=${INSTALL_PREFIX}/bin:$PATH
 - export TESTLUA=$(which luajit lua | head -n 1)


### PR DESCRIPTION
Install luaffi module in non-LuaJIT builds to fix test failure and remove OpenBLAS installation to speed up continuous build.