### PR TITLE
Load thread's start routine from separate shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ install_manifest.txt
 # Build output
 libthreads.a
 libthreads.so
+libthreadsmain.dylib
+libthreadsmain.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,14 @@ set(luasrc
 )
 
 add_torch_package(threads "${src}" "${luasrc}" "Threads")
-
 target_link_libraries(threads luaT TH)
+
+ADD_LIBRARY(threadsmain MODULE lib/thread-main.c)
+IF(APPLE)
+  SET_TARGET_PROPERTIES(threadsmain PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup")
+ENDIF()
+INSTALL(TARGETS threadsmain LIBRARY DESTINATION "${Torch_INSTALL_LIB_SUBDIR}")
 
 if(WIN32)
   add_definitions(-DUSE_WIN_THREADS=1)

--- a/lib/THThread.h
+++ b/lib/THThread.h
@@ -4,8 +4,12 @@
 typedef struct THThread_ THThread;
 typedef struct THMutex_ THMutex;
 typedef struct THCondition_ THCondition;
+typedef struct THThreadState_ {
+  void* data;
+  int status;
+} THThreadState;
 
-THThread* THThread_new(int (*closure)(void*), void *data);
+THThread* THThread_new(void* (*closure)(void*), void *data);
 long THThread_id(THThread *self);
 int THThread_free(THThread *self);
 

--- a/lib/thread-main.c
+++ b/lib/thread-main.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+#include "THThread.h"
+
+static int runthread(void *code_)
+{
+  char *code = code_;
+  lua_State *L = luaL_newstate();
+
+  if(!L) {
+    printf("THREAD FATAL ERROR: could not create lua state\n");
+    return -1;
+  }
+  luaL_openlibs(L);
+
+  if(luaL_loadstring(L, code)) {
+    printf("FATAL THREAD PANIC: (loadstring) %s\n", lua_tolstring(L, -1, NULL));
+    free(code);
+    lua_close(L);
+    return -1;
+  }
+
+  free(code);
+  if(lua_pcall(L, 0, 0, 0)) {
+    printf("FATAL THREAD PANIC: (pcall) %s\n", lua_tolstring(L, -1, NULL));
+    lua_close(L);
+    return -1;
+  }
+
+  lua_close(L);
+  return 0;
+}
+
+void* THThread_main(void *arg)
+{
+  THThreadState* state = arg;
+  state->status = runthread(state->data);
+  return NULL;
+}

--- a/test/test-threads-error.lua
+++ b/test/test-threads-error.lua
@@ -1,0 +1,17 @@
+local threads = require 'threads'
+
+local t = threads.Threads(1, function()
+    sys = require 'sys'
+end)
+
+-- Trigger an error in an endcallback. The callback is run during lua_close
+-- when the Threads:synchronize method is called from the __gc metamethod.
+-- The error may prevent the thread from terminating before the threads module
+-- and libthreads.so is unloaded. In previous versions of threads this would
+-- cause a segfault.
+
+t:addjob(function()
+	sys.sleep(0.1)
+end, function()
+    error('error from callback')
+end)


### PR DESCRIPTION
Prior to this change, if Lua unloads the threads library before the child
threads terminate, the program wil segfault. This could happen if an error
is triggered during an endcallback, preventing the child thread from exiting.

This places the thread's start routine in a separate shared library:
libthreadmain, which is loaded once and never unloaded.

Fixes #39