### PR TITLE
Fix pointer overflows in sharedserialize

### DIFF
--- a/sharedserialize.lua
+++ b/sharedserialize.lua
@@ -27,13 +27,22 @@ if tds then
    -- vec
    local mt = {}
    function mt.__factory(f)
-      local self = f:readLong()
+      local self
+      if ffi.sizeof('long') == 4 then
+         self = f:readDouble()
+      else
+         self = f:readLong()
+      end
       self = ffi.cast('tds_vec&', self)
       ffi.gc(self, tds.C.tds_vec_free)
       return self
    end
    function mt.__write(self, f)
-      f:writeLong(torch.pointer(self))
+      if ffi.sizeof('long') == 4 then
+         f:writeDouble(torch.pointer(self))
+      else
+         f:writeLong(torch.pointer(self))
+      end
       tds.C.tds_vec_retain(self)
    end
    function mt.__read(self, f)


### PR DESCRIPTION
Addresses #55. Signed long type can't represent all possible pointer values, so the read value can be different than the saved one (it was truncated during save). On 32-bit systems it can be easily fixed by saving the pointer in a double type, and on 64-bit systems, the values will first hit the 2^53 max integer double limit (this will be caught in luaT with torch/torch7#647).