### PR TITLE
add broadcast operation for condition variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,11 @@ has been raised.
 
 Raise the condition signal.
 
+<a name='condition.broadcast'/>
+#### Condition.broadcast() ####
+
+Broadcast the condition signal to all waiting threads.
+
 <a name='condition.free'/>
 #### Condition.free() ####
 

--- a/lib/THThread.c
+++ b/lib/THThread.c
@@ -216,6 +216,13 @@ int THCondition_signal(THCondition *self)
   return 0;
 }
 
+int THCondition_broadcast(THCondition *self)
+{
+  if(pthread_cond_broadcast(&self->id))
+    return 1;
+  return 0;
+}
+
 int THCondition_wait(THCondition *self, THMutex *mutex)
 {
   if(pthread_cond_wait(&self->id, &mutex->id))

--- a/lib/THThread.h
+++ b/lib/THThread.h
@@ -34,6 +34,7 @@ THCondition* THCondition_new(void);
 THCondition* THCondition_newWithId(AddressType id);
 AddressType THCondition_id(THCondition *self);
 int THCondition_signal(THCondition *self);
+int THCondition_broadcast(THCondition *self);
 int THCondition_wait(THCondition *self, THMutex *mutex);
 void THCondition_free(THCondition *self);
 

--- a/lib/threads.c
+++ b/lib/threads.c
@@ -195,6 +195,14 @@ static int condition_signal(lua_State *L)
   return 0;
 }
 
+static int condition_broadcast(lua_State *L)
+{
+  THCondition *condition = luaTHRD_checkudata(L, 1, "threads.Condition");
+  if(THCondition_broadcast(condition))
+    luaL_error(L, "threads: condition signal failed");
+  return 0;
+}
+
 static int condition_wait(lua_State *L)
 {
   THCondition *condition = luaTHRD_checkudata(L, 1, "threads.Condition");
@@ -227,6 +235,7 @@ static const struct luaL_Reg condition__ [] = {
   {"__tostring", condition_tostring},
   {"id", condition_id},
   {"signal", condition_signal},
+  {"broadcast", condition_broadcast},
   {"wait", condition_wait},
   {"free", condition_free},
   {NULL, NULL}


### PR DESCRIPTION
Currently the condition variable interface lacks the "broadcast" operation, which translates to `pthread_cond_broadcast`. This is a very useful operation for signaling multiple threads.
This PR just add a `broadcast` function for Condition in a straightforward way.